### PR TITLE
Problems with terminal output fixed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8-bom
+indent_style = space
+indent_size = 4
+tab_width = 4

--- a/src/Swan.Lite/Swan.Lite.csproj
+++ b/src/Swan.Lite/Swan.Lite.csproj
@@ -8,13 +8,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Swan.Lite</AssemblyName>
     <CodeAnalysisRuleSet>..\..\StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <Authors>Unosquare</Authors>
     <PackageIconUrl>https://github.com/unosquare/swan/raw/master/swan-logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/unosquare/swan</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/unosquare/swan/master/LICENSE</PackageLicenseUrl>
     <PackageTags>best-practices netcore network objectmapper json-serialization</PackageTags>
     <LangVersion>7.3</LangVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Swan.Lite/Terminal.Interaction.cs
+++ b/src/Swan.Lite/Terminal.Interaction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Swan.Logging;
 
 namespace Swan
@@ -69,6 +70,15 @@ namespace Swan
         #endregion
 
         #region Other Terminal Read Methods
+
+        /// <summary>
+        /// Clears the screen.
+        /// </summary>
+        public static void Clear()
+        {
+            Flush();
+            Console.Clear();
+        }
 
         /// <summary>
         /// Reads a line of text from the console.
@@ -149,7 +159,7 @@ namespace Swan
             if (!IsConsolePresent) return default;
 
             const ConsoleColor textColor = ConsoleColor.White;
-            var lineLength = Console.BufferWidth;
+            var lineLength = Console.WindowWidth;
             var lineAlign = -(lineLength - 2);
             var textFormat = "{0," + lineAlign + "}";
 
@@ -166,7 +176,7 @@ namespace Swan
                 {
                     // Title
                     Table.Vertical();
-                    var titleText = string.Format(
+                    var titleText = string.Format(CultureInfo.CurrentCulture,
                         textFormat,
                         string.IsNullOrWhiteSpace(title) ? " Select an option from the list below." : $" {title}");
                     Write(titleText, textColor);
@@ -184,7 +194,7 @@ namespace Swan
                 foreach (var kvp in options)
                 {
                     Table.Vertical();
-                    Write(string.Format(textFormat,
+                    Write(string.Format(CultureInfo.CurrentCulture, textFormat,
                         $"    {"[ " + kvp.Key + " ]",-10}  {kvp.Value}"), textColor);
                     Table.Vertical();
                 }
@@ -193,11 +203,11 @@ namespace Swan
                 if (string.IsNullOrWhiteSpace(anyKeyOption) == false)
                 {
                     Table.Vertical();
-                    Write(string.Format(textFormat, " "), ConsoleColor.Gray);
+                    Write(string.Format(CultureInfo.CurrentCulture, textFormat, " "), ConsoleColor.Gray);
                     Table.Vertical();
 
                     Table.Vertical();
-                    Write(string.Format(textFormat,
+                    Write(string.Format(CultureInfo.CurrentCulture, textFormat,
                         $"    {" ",-10}  {anyKeyOption}"), ConsoleColor.Gray);
                     Table.Vertical();
                 }
@@ -209,7 +219,7 @@ namespace Swan
                     Table.RightTee();
 
                     Table.Vertical();
-                    Write(string.Format(textFormat, Settings.UserOptionText), ConsoleColor.Green);
+                    Write(string.Format(CultureInfo.CurrentCulture, textFormat, Settings.UserOptionText), ConsoleColor.Green);
                     Table.Vertical();
 
                     Table.BottomLeft();

--- a/src/Swan.Lite/Terminal.cs
+++ b/src/Swan.Lite/Terminal.cs
@@ -287,7 +287,7 @@ namespace Swan
                 if (!OutputQueue.TryDequeue(out var context)) continue;
 
                 // Process Console output and Skip over stuff we can't display so we don't stress the output too much.
-                if (!IsConsolePresent || OutputQueue.Count > Console.BufferHeight) continue;
+                if (!IsConsolePresent) continue;
 
                 Console.ForegroundColor = context.OutputColor;
 
@@ -332,7 +332,7 @@ namespace Swan
             public ConsoleColor OutputColor { get; set; }
             public char[] OutputText { get; set; }
             public TerminalWriters OutputWriters { get; set; }
-        }
+	    }
 
         #endregion
     }

--- a/src/Swan.Samples/Program.cs
+++ b/src/Swan.Samples/Program.cs
@@ -28,7 +28,14 @@
             TestJson();
             TestApplicationInfo();
             await TestTerminalOutputs();
-            await TestNetworkUtilities();
+			try
+			{
+				await TestNetworkUtilities();
+			}
+			catch (System.Net.Http.HttpRequestException x)
+			{
+				Terminal.WriteLine($"Error testing network {x}", ConsoleColor.Red, TerminalWriters.StandardError);
+			}
             TestContainerAndMessageHub();
             TestExceptionLogging();
 

--- a/src/Swan.Samples/Program.cs
+++ b/src/Swan.Samples/Program.cs
@@ -12,6 +12,7 @@
     using Net;
     using System.Linq;
     using System.Threading.Tasks;
+    using System.Text;
 
     public static partial class Program
     {
@@ -31,7 +32,8 @@
             TestContainerAndMessageHub();
             TestExceptionLogging();
 
-            TestFastOutputAndReadPrompt();
+            TestFastOutput();
+            TestReadPrompt();
             TestCsvFormatters();
             Terminal.Flush();
             Terminal.ReadKey("Enter any key to exit . . .");
@@ -127,19 +129,26 @@
             messageHub.Publish(new SampleMessage("SENDER HERE", "This is some sample text"));
         }
 
-        private static void TestFastOutputAndReadPrompt()
+        private static void TestFastOutput()
         {
             var limit = Console.BufferHeight;
             for (var i = 0; i < limit; i += 25)
             {
-                Terminal.WriteLine($"Output info {i} ({((decimal) i / limit):P})");
+                Terminal.WriteLine($"Output info {i} ({((decimal)i / limit):P})");
                 Terminal.BacklineCursor();
             }
+        }
 
+        private static void TestReadPrompt()
+        {
+            Terminal.Clear();
             var sampleOptions = new Dictionary<ConsoleKey, string>
             {
                 {ConsoleKey.A, "Sample A"},
-                {ConsoleKey.B, "Sample B"}
+                {ConsoleKey.B, "Sample B"},
+                {ConsoleKey.C, "Sample C" },
+                {ConsoleKey.D, "Sample D" },
+                {ConsoleKey.E, "Sample E" }
             };
 
             Terminal.ReadPrompt("Please provide an option", sampleOptions, "Exit this program");
@@ -154,6 +163,8 @@
             }
 
             if (Terminal.ReadKey("Press a key to output the current codepage. (X) will exit.").Key == ConsoleKey.X) return;
+            // Although .NET is by default Unicode, this explicit instruction causes Linux to print mostly garbage
+            // Terminal.OutputEncoding = Encoding.Unicode;
             Terminal.WriteLine("CODEPAGE TEST", ConsoleColor.Blue);
             Terminal.PrintCurrentCodePage();
 

--- a/src/Swan.Samples/Properties/PublishProfiles/Linux-Arm.pubxml
+++ b/src/Swan.Samples/Properties/PublishProfiles/Linux-Arm.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <PublishDir>C:\projects\swan\src\Swan.Samples\bin\Debug\netcoreapp2.2\linux-arm\publish</PublishDir>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+  </PropertyGroup>
+</Project>

--- a/src/Swan/Swan.csproj
+++ b/src/Swan/Swan.csproj
@@ -8,13 +8,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Swan</AssemblyName>
     <CodeAnalysisRuleSet>..\..\StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
-    <Version>2.0.1</Version>
+    <Version>2.2.3</Version>
     <Authors>Unosquare</Authors>
     <PackageIconUrl>https://github.com/unosquare/swan/raw/master/swan-logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/unosquare/swan</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/unosquare/swan/master/LICENSE</PackageLicenseUrl>
     <PackageTags>best-practices netcore network objectmapper json-serialization</PackageTags>
 	  <LangVersion>7.3</LangVersion>
+	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should finally fix the terminal output on the Raspberry. Final confirmation with Unosquare.RaspberryPi in progress.

I suggest to split up the Terminal class into one for the logging (which may use an async queue) and one for direct use from client apps, without a queue.