### PR TITLE
[FIX] IComponentCollection<T>.Add should declare name as nullable.

### DIFF
--- a/src/Swan.Lite/Collections/ComponentCollection`1.cs
+++ b/src/Swan.Lite/Collections/ComponentCollection`1.cs
@@ -42,7 +42,7 @@ namespace Swan.Collections
 
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException">The collection is locked.</exception>
-        public void Add(string name, T component)
+        public void Add(string? name, T component)
         {
             EnsureConfigurationNotLocked();
 

--- a/src/Swan.Lite/Collections/IComponentCollection`1.cs
+++ b/src/Swan.Lite/Collections/IComponentCollection`1.cs
@@ -49,6 +49,6 @@ namespace Swan.Collections
         /// </summary>
         /// <param name="name">The name given to the module, or <see langword="null"/>.</param>
         /// <param name="component">The component.</param>
-        void Add(string name, T component);
+        void Add(string? name, T component);
     }
 }


### PR DESCRIPTION
This also causes unnecessary warnings in EmbedIO.