### PR TITLE
Adding default arg option

### DIFF
--- a/src/Swan.Lite/Parsers/ArgumentOptionAttribute.cs
+++ b/src/Swan.Lite/Parsers/ArgumentOptionAttribute.cs
@@ -89,5 +89,13 @@ namespace Swan.Parsers
         /// The help text.
         /// </value>
         public string? HelpText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default argument.
+        /// </summary>
+        /// <value>
+        /// The default argument.
+        /// </value>
+        public bool DefaultArg { get; set; }
     }
 }

--- a/src/Swan.Lite/Parsers/ArgumentOptionAttribute.cs
+++ b/src/Swan.Lite/Parsers/ArgumentOptionAttribute.cs
@@ -96,6 +96,6 @@ namespace Swan.Parsers
         /// <value>
         /// The default argument.
         /// </value>
-        public bool DefaultArg { get; set; }
+        public bool IsDefault { get; set; }
     }
 }

--- a/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
@@ -87,9 +87,7 @@ namespace Swan.Parsers
                 {
                     var optionAttr = AttributeCache.DefaultCache.Value.RetrieveOne<ArgumentOptionAttribute>(targetProperty);
 
-                    var isDefaultArg = optionAttr.IsDefault;
-
-                    if (!isDefaultArg)
+                    if (!optionAttr.IsDefault)
                         continue;
 
                     var defaultArgValue = _args.FirstOrDefault();

--- a/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
@@ -27,7 +27,8 @@ namespace Swan.Parsers
                 PropertyInfo[] properties,
                 IEnumerable<string> args,
                 object instance,
-                ArgumentParserSettings settings)
+                ArgumentParserSettings settings,
+                bool hasVerb = false)
             {
                 _args = args;
                 _instance = instance;
@@ -35,7 +36,7 @@ namespace Swan.Parsers
                 _properties = properties;
 
                 PopulateInstance();
-                SetDefaultArg();
+                if (!hasVerb) SetDefaultArgument();
                 SetDefaultValues();
                 GetRequiredList();
             }
@@ -81,7 +82,7 @@ namespace Swan.Parsers
                 }
             }
 
-            private void SetDefaultArg()
+            private void SetDefaultArgument()
             {
                 foreach (var targetProperty in _properties.Except(_updatedList))
                 {

--- a/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
@@ -19,6 +19,7 @@ namespace Swan.Parsers
             private readonly IEnumerable<string> _args;
             private readonly List<PropertyInfo> _updatedList = new List<PropertyInfo>();
             private readonly ArgumentParserSettings _settings;
+            const char dash = '-';
 
             private readonly PropertyInfo[] _properties;
 
@@ -34,6 +35,7 @@ namespace Swan.Parsers
                 _properties = properties;
 
                 PopulateInstance();
+                SetDefaultArg();
                 SetDefaultValues();
                 GetRequiredList();
             }
@@ -79,9 +81,28 @@ namespace Swan.Parsers
                 }
             }
 
+            private void SetDefaultArg()
+            {
+                foreach (var targetProperty in _properties.Except(_updatedList))
+                {
+                    var optionAttr = AttributeCache.DefaultCache.Value.RetrieveOne<ArgumentOptionAttribute>(targetProperty);
+
+                    var isDefaultArg = optionAttr.DefaultArg;
+
+                    if (!isDefaultArg)
+                        continue;
+
+                    var defaultArgValue = _args.FirstOrDefault();
+                    if (string.IsNullOrWhiteSpace(defaultArgValue) || defaultArgValue[0] == dash)
+                        continue;
+
+                    if (SetPropertyValue(targetProperty, defaultArgValue, _instance, optionAttr))
+                        _updatedList.Add(targetProperty);
+                }
+            }
+
             private void PopulateInstance()
             {
-                const char dash = '-';
                 var propertyName = string.Empty;
 
                 foreach (var arg in _args)

--- a/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
@@ -87,13 +87,13 @@ namespace Swan.Parsers
                 {
                     var optionAttr = AttributeCache.DefaultCache.Value.RetrieveOne<ArgumentOptionAttribute>(targetProperty);
 
-                    var isDefaultArg = optionAttr.DefaultArg;
+                    var isDefaultArg = optionAttr.IsDefault;
 
                     if (!isDefaultArg)
                         continue;
 
                     var defaultArgValue = _args.FirstOrDefault();
-                    if (string.IsNullOrWhiteSpace(defaultArgValue) || defaultArgValue[0] == dash)
+                    if (string.IsNullOrWhiteSpace(defaultArgValue) || defaultArgValue[0] == OptionSwitchChar)
                         continue;
 
                     if (SetPropertyValue(targetProperty, defaultArgValue, _instance, optionAttr))
@@ -111,11 +111,11 @@ namespace Swan.Parsers
 
                     if (ignoreSetValue)
                     {
-                        if (string.IsNullOrWhiteSpace(arg) || arg[0] != dash) continue;
+                        if (string.IsNullOrWhiteSpace(arg) || arg[0] != OptionSwitchChar) continue;
 
                         propertyName = arg.Substring(1);
 
-                        if (!string.IsNullOrWhiteSpace(propertyName) && propertyName[0] == dash)
+                        if (!string.IsNullOrWhiteSpace(propertyName) && propertyName[0] == OptionSwitchChar)
                             propertyName = propertyName.Substring(1);
                     }
 

--- a/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParse.Validator.cs
@@ -15,11 +15,11 @@ namespace Swan.Parsers
     {
         private sealed class Validator
         {
+            private const char OptionSwitchChar = '-';
             private readonly object _instance;
             private readonly IEnumerable<string> _args;
             private readonly List<PropertyInfo> _updatedList = new List<PropertyInfo>();
             private readonly ArgumentParserSettings _settings;
-            const char dash = '-';
 
             private readonly PropertyInfo[] _properties;
 

--- a/src/Swan.Lite/Parsers/ArgumentParser.TypeResolver.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParser.TypeResolver.cs
@@ -12,7 +12,7 @@ namespace Swan.Parsers
     {
         private sealed class TypeResolver<T>
         {
-            public bool HasVerb { get => _hasVerb; }
+            public bool HasVerb { get; }
 
             private bool _hasVerb = false;
 

--- a/src/Swan.Lite/Parsers/ArgumentParser.TypeResolver.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParser.TypeResolver.cs
@@ -12,6 +12,10 @@ namespace Swan.Parsers
     {
         private sealed class TypeResolver<T>
         {
+            public bool HasVerb { get => _hasVerb; }
+
+            private bool _hasVerb = false;
+
             private readonly string _selectedVerb;
 
             private PropertyInfo[]? _properties;
@@ -29,6 +33,8 @@ namespace Swan.Parsers
 
                 if (!_properties.Any(x => x.GetCustomAttributes(typeof(VerbOptionAttribute), false).Any()))
                     return instance;
+
+                _hasVerb = true;
 
                 var selectedVerb = string.IsNullOrWhiteSpace(_selectedVerb)
                     ? null

--- a/src/Swan.Lite/Parsers/ArgumentParser.cs
+++ b/src/Swan.Lite/Parsers/ArgumentParser.cs
@@ -1,4 +1,4 @@
-using Swan.Reflection;
+﻿using Swan.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -196,7 +196,7 @@ namespace Swan.Parsers
             if (typeResolver.Properties == null)
                 throw new InvalidOperationException($"Type {typeof(T).Name} is not valid");
 
-            var validator = new Validator(typeResolver.Properties, args, options, Settings);
+            var validator = new Validator(typeResolver.Properties, args, options, Settings, typeResolver.HasVerb);
 
             if (validator.IsValid())
                 return true;

--- a/test/Swan.Test/ArgumentParserTest.cs
+++ b/test/Swan.Test/ArgumentParserTest.cs
@@ -22,6 +22,18 @@
         }
 
         [Test]
+        public void BasicDefaultArgument_ReturnsEquals()
+        {
+            var dumpArgs = new[] { "kezo", "--verbose" };
+            var result = ArgumentParser.Current.ParseArguments<OptionMock>(dumpArgs, out var options);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(options.Verbose);
+            Assert.AreEqual(dumpArgs[0], options.Username);
+            Assert.AreEqual(ConsoleColor.Red, options.BgColor, "Default color");
+        }
+
+        [Test]
         public void InvalidDataConversion_ReturnsFalse()
         {
             var options = new OptionIntRequiredMock();

--- a/test/Swan.Test/Mocks/OptionMock.cs
+++ b/test/Swan.Test/Mocks/OptionMock.cs
@@ -12,7 +12,7 @@
         [ArgumentOption("color", DefaultValue = ConsoleColor.Red, HelpText = "Set background color.")]
         public ConsoleColor BgColor { get; set; }
 
-        [ArgumentOption('n', DefaultArg = true, Required = true, HelpText = "Set user name.")]
+        [ArgumentOption('n', IsDefault = true, Required = true, HelpText = "Set user name.")]
         public string Username { get; set; }
 
         [ArgumentOption('o', "options", Separator = ',', HelpText = "Specify additional options.")]

--- a/test/Swan.Test/Mocks/OptionMock.cs
+++ b/test/Swan.Test/Mocks/OptionMock.cs
@@ -12,7 +12,7 @@
         [ArgumentOption("color", DefaultValue = ConsoleColor.Red, HelpText = "Set background color.")]
         public ConsoleColor BgColor { get; set; }
 
-        [ArgumentOption('n', Required = true, HelpText = "Set user name.")]
+        [ArgumentOption('n', DefaultArg = true, Required = true, HelpText = "Set user name.")]
         public string Username { get; set; }
 
         [ArgumentOption('o', "options", Separator = ',', HelpText = "Specify additional options.")]


### PR DESCRIPTION
Related to https://github.com/unosquare/swan/issues/223

I am adding a new **ArgumentOptionAttribute** to mark an argument as the default one.
This means you could pass the first argument as the default property without the property name.